### PR TITLE
Update for mac installer

### DIFF
--- a/installer/create_installer_web.m
+++ b/installer/create_installer_web.m
@@ -90,6 +90,9 @@ end
 
 function qversion = getVersionFromGit()
     global rootDir;
+    % setting default version
+    qversion = defaultVersion();
+
     % Save the current directory
     currentDir = pwd;
 
@@ -120,17 +123,20 @@ function qversion = getVersionFromGit()
             
             qversion = getVersionString(tag, codeChangeDetected);
         else
-            warning('Error: Unable to retrieve the latest tag. Check if git is installed.');
-            qversion = "2.1.1";
+            warning('Error: Unable to retrieve the latest tag. Check if git is installed. Resolving to default version.');
         end
 
     else
-        error('Not in a Git repository. Make sure you are running from a git repository.');
+        warning('Not in a Git repository. Make sure you are running from a git repository. Resolving to default version.');
     end
 
     % Return to the original directory
     fprintf("Reverting current directory back to %s", currentDir);
     cd(currentDir);
+end
+
+function qversion = defaultVersion()
+    qversion = '2.1.2';
 end
 
 function versionString = getVersionString(tag, codeChanged)


### PR DESCRIPTION
Update for MacOS installer

I'm just adding support for the Mac installer.

- [x] All existing scripts remains the same.
- [x] Handle git failures gracefully.

Testing : 
Tested by creating an installer on a Mac machine and installing it.  

Note : This will work only on Intel machines. Arm chip (M1, M2) support has to be added after porta is replaced.

Signing has to be added for seamless installation and launch.